### PR TITLE
Use native method for env variable fetching

### DIFF
--- a/tmdbsimple/__init__.py
+++ b/tmdbsimple/__init__.py
@@ -36,12 +36,6 @@ from .people import People, Credits, Jobs
 from .search import Search
 from .tv import TV, TV_Seasons, TV_Episodes, Networks
 
-def _get_env_key(key):
-    try:
-        return os.environ[key]
-    except KeyError:
-        return None
 
-API_KEY = _get_env_key('TMDB_API_KEY')
+API_KEY = os.environ.get('TMDB_API_KEY', None)
 API_VERSION = '3'
-


### PR DESCRIPTION
Use `os.environ.get()`, which uses [`dict.get`](https://docs.python.org/2/library/stdtypes.html#dict.get) to set a fallback value for environment variables that might not be set instead of a custom function.
If the value is not set, it defaults to `None`
