### PR TITLE
Added passing of requests session object.

### DIFF
--- a/tmdbsimple/__init__.py
+++ b/tmdbsimple/__init__.py
@@ -4,11 +4,11 @@
 tmdbsimple
 ~~~~~~~~~~
 
-*tmdbsimple* is a wrapper, written in Python, for The Movie Database (TMDb) 
-API v3.  By calling the functions available in *tmdbsimple* you can simplify 
-your code and easily access a vast amount of movie, tv, and cast data.  To find 
-out more about The Movie Database API, check out the overview page 
-http://www.themoviedb.org/documentation/api and documentation page 
+*tmdbsimple* is a wrapper, written in Python, for The Movie Database (TMDb)
+API v3.  By calling the functions available in *tmdbsimple* you can simplify
+your code and easily access a vast amount of movie, tv, and cast data.  To find
+out more about The Movie Database API, check out the overview page
+http://www.themoviedb.org/documentation/api and documentation page
 http://docs.themoviedb.apiary.io.
 https://www.themoviedb.org/documentation/api/status-codes
 
@@ -44,4 +44,5 @@ def _get_env_key(key):
 
 API_KEY = _get_env_key('TMDB_API_KEY')
 API_VERSION = '3'
+REQUESTS_SESSION = None
 

--- a/tmdbsimple/base.py
+++ b/tmdbsimple/base.py
@@ -27,9 +27,11 @@ class TMDB(object):
     URLS = {}
 
     def __init__(self):
-        from . import API_VERSION
+        from . import API_VERSION, REQUESTS_SESSION, __version__
         self.base_uri = 'https://api.themoviedb.org'
         self.base_uri += '/{version}'.format(version=API_VERSION)
+        self.session = REQUESTS_SESSION or requests.Session()
+        self.session.headers.setdefault('user-agent', 'tmdb_api/{}.{}.{}'.format(*__version__))
 
     def _get_path(self, key):
         return self.BASE_PATH + self.URLS[key]
@@ -40,7 +42,7 @@ class TMDB(object):
     def _get_guest_session_id_path(self, key):
         return self._get_path(key).format(
             guest_session_id=self.guest_session_id)
-    
+
     def _get_credit_id_path(self, key):
         return self._get_path(key).format(credit_id=self.credit_id)
 
@@ -72,8 +74,8 @@ class TMDB(object):
         url = self._get_complete_url(path)
         params = self._get_params(params)
 
-        response = requests.request(
-            method, url, params=params, 
+        response = self.session.request(
+            method, url, params=params,
             data=json.dumps(payload) if payload else payload,
             headers=self.headers)
 

--- a/tmdbsimple/tv.py
+++ b/tmdbsimple/tv.py
@@ -3,7 +3,7 @@
 """
 tmdbsimple.tv
 ~~~~~~~~~~~~~
-This module implements the TV, TV Seasons, TV Episodes, and Networks 
+This module implements the TV, TV Seasons, TV Episodes, and Networks
 functionality of tmdbsimple.
 
 Created by Celia Oakley on 2013-10-31.
@@ -47,7 +47,7 @@ class TV(TMDB):
 
         Args:
             language: (optional) ISO 639 code.
-            append_to_response: (optional) Comma separated, any TV series 
+            append_to_response: (optional) Comma separated, any TV series
                                 method.
 
         Returns:
@@ -61,12 +61,12 @@ class TV(TMDB):
 
     def credits(self, **kwargs):
         """
-        Get the cast & crew information about a TV series. Just like the 
+        Get the cast & crew information about a TV series. Just like the
         website, we pull this information from the last season of the series.
 
         Args:
             language: (optional) ISO 639 code.
-            append_to_response: (optional) Comma separated, any collection 
+            append_to_response: (optional) Comma separated, any collection
                                 method.
 
         Returns:
@@ -100,7 +100,7 @@ class TV(TMDB):
 
         Args:
             language: (optional) ISO 639 code.
-            include_image_language: (optional) Comma separated, a valid 
+            include_image_language: (optional) Comma separated, a valid
                                     ISO 69-1.
 
         Returns:
@@ -138,7 +138,7 @@ class TV(TMDB):
     def similar(self, **kwargs):
         """
         Get the similar TV series for a specific TV series id.
-        
+
         Args:
             page: (optional) Minimum value of 1.  Expected value is an integer.
             language: (optional) ISO 639-1 code.
@@ -155,7 +155,7 @@ class TV(TMDB):
 
     def translations(self, **kwargs):
         """
-        Get the list of translations that exist for a TV series. These 
+        Get the list of translations that exist for a TV series. These
         translations cascade down to the episode level.
 
         Returns:
@@ -224,8 +224,8 @@ class TV(TMDB):
 
     def top_rated(self, **kwargs):
         """
-        Get the list of top rated TV shows. By default, this list will only 
-        include TV shows that have 2 or more votes. This list refreshes every 
+        Get the list of top rated TV shows. By default, this list will only
+        include TV shows that have 2 or more votes. This list refreshes every
         day.
 
         Args:
@@ -267,7 +267,7 @@ class TV_Seasons(TMDB):
     BASE_PATH = 'tv/{id}/season/{season_number}'
     URLS = {
         'info': '',
-        'credits': '/credits', 
+        'credits': '/credits',
         'external_ids': '/external_ids',
         'images': '/images',
         'videos': '/videos',
@@ -284,7 +284,7 @@ class TV_Seasons(TMDB):
 
         Args:
             language: (optional) ISO 639 code.
-            append_to_response: (optional) Comma separated, any TV series 
+            append_to_response: (optional) Comma separated, any TV series
                                 method.
 
         Returns:
@@ -311,7 +311,7 @@ class TV_Seasons(TMDB):
 
     def external_ids(self, **kwargs):
         """
-        Get the external ids that we have stored for a TV season by season 
+        Get the external ids that we have stored for a TV season by season
         number.
 
         Args:
@@ -328,12 +328,12 @@ class TV_Seasons(TMDB):
 
     def images(self, **kwargs):
         """
-        Get the images (posters) that we have stored for a TV season by season 
+        Get the images (posters) that we have stored for a TV season by season
         number.
 
         Args:
             language: (optional) ISO 639 code.
-            include_image_language: (optional) Comma separated, a valid 
+            include_image_language: (optional) Comma separated, a valid
                                     ISO 69-1.
 
         Returns:
@@ -371,7 +371,7 @@ class TV_Episodes(TMDB):
     BASE_PATH = 'tv/{series_id}/season/{season_number}/episode/{episode_number}'
     URLS = {
         'info': '',
-        'credits': '/credits', 
+        'credits': '/credits',
         'external_ids': '/external_ids',
         'images': '/images',
         'rating': '/rating',
@@ -386,12 +386,12 @@ class TV_Episodes(TMDB):
 
     def info(self, **kwargs):
         """
-        Get the primary information about a TV episode by combination of a 
+        Get the primary information about a TV episode by combination of a
         season and episode number.
 
         Args:
             language: (optional) ISO 639 code.
-            append_to_response: (optional) Comma separated, any TV series 
+            append_to_response: (optional) Comma separated, any TV series
                                 method.
 
         Returns:
@@ -418,7 +418,7 @@ class TV_Episodes(TMDB):
 
     def external_ids(self, **kwargs):
         """
-        Get the external ids for a TV episode by combination of a season and 
+        Get the external ids for a TV episode by combination of a season and
         episode number.
 
         Args:
@@ -436,8 +436,8 @@ class TV_Episodes(TMDB):
 
     def images(self, **kwargs):
         """
-        Get the images (episode stills) for a TV episode by combination of a 
-        season and episode number. Since episode stills don't have a language, 
+        Get the images (episode stills) for a TV episode by combination of a
+        season and episode number. Since episode stills don't have a language,
         this call will always return all images.
 
         Returns:
@@ -506,8 +506,8 @@ class Networks(TMDB):
 
     def info(self, **kwargs):
         """
-        This method is used to retrieve the basic information about a TV 
-        network. You can use this ID to search for TV shows with the discover. 
+        This method is used to retrieve the basic information about a TV
+        network. You can use this ID to search for TV shows with the discover.
         At this time we don't have much but this will be fleshed out over time.
 
         Returns:


### PR DESCRIPTION
This can be optionally used to reuse an existing requests session. For example when CacheControl is used icw the session object. Eventually it should reduce the load on tmdb, as we're making use of cache as much as possible.

* Also did some small cleanups. In remove trailing spaces.