### PR TITLE
Use _gte and _lte instead of .gte and .lte

### DIFF
--- a/tmdbsimple/discover.py
+++ b/tmdbsimple/discover.py
@@ -43,10 +43,10 @@ class Discover(TMDB):
             primary_release_year: (optional) Filter the results so that 
                                   only the primary release date year has 
                                   this value.  Expected value is a year.
-            vote_count.gte: (optional) Only include movies that are equal to,
+            vote_count_gte: (optional) Only include movies that are equal to,
                             or have a vote count higher than this value. 
                             Expected value is an integer.
-            vote_average.gte: (optional) Only include movies that are equal 
+            vote_average_gte: (optional) Only include movies that are equal 
                               to, or have a higher average rating than this 
                               value.  Expected value is a float.
             with_genres: (optional) Only include movies with the specified 
@@ -54,15 +54,15 @@ class Discover(TMDB):
                          a genre).  Multiple values can be specified. 
                          Comma separated indicates an 'AND' query, while 
                          a pipe (|) separated value indicates an 'OR'.
-            release_date.gte: (optional) The minimum release to include.
+            release_date_gte: (optional) The minimum release to include.
                               Expected format is 'YYYY-MM-DD'.
-            release_date.lte: (optional) The maximum release to include. 
+            release_date_lte: (optional) The maximum release to include. 
                               Expected format is 'YYYY-MM-DD'.
             certification_country: (optional) Only include movies with
                                    certifications for a specific country. When
                                    this value is specified, 'certification.lte'
                                    is required. An ISO 3166-1 is expected.
-            certification.lte: (optional) Only include movies with this
+            certification_lte: (optional) Only include movies with this
                                certification and lower. Expected value is a 
                                valid certification for the specified 
                                'certification_country'.
@@ -74,6 +74,14 @@ class Discover(TMDB):
         Returns:
             A dict respresentation of the JSON returned from the API.
         """
+        # Periods are not allowed in keyword arguments but severall API 
+        # arguments contain periods. 
+        for param in kwargs:
+            if '_lte' in param:
+                kwargs[param.replace('_lte', '.lte')] = kwargs.pop(param)
+            if '_gte' in param:
+                kwargs[param.replace('_gte', '.gte')] = kwargs.pop(param)
+        
         path = self._get_path('movie')
 
         response = self._GET(path, kwargs)
@@ -94,10 +102,10 @@ class Discover(TMDB):
             first_air_year: (optional) Filter the results release dates to 
                             matches that include this value. Expected value 
                             is a year.
-            vote_count.gte: (optional) Only include TV shows that are equal to,
+            vote_count_gte: (optional) Only include TV shows that are equal to,
                             or have vote count higher than this value. Expected
                             value is an integer.
-            vote_average.gte: (optional) Only include TV shows that are equal 
+            vote_average_gte: (optional) Only include TV shows that are equal 
                               to, or have a higher average rating than this 
                               value.  Expected value is a float.
             with_genres: (optional) Only include TV shows with the specified 
@@ -109,14 +117,22 @@ class Discover(TMDB):
                            network. Expected value is an integer (the id of a
                            network).  They can be comma separated to indicate an
                            'AND' query.
-            first_air_date.gte: (optional) The minimum release to include. 
+            first_air_date_gte: (optional) The minimum release to include. 
                                 Expected format is 'YYYY-MM-DD'.
-            first_air_date.lte: (optional) The maximum release to include. 
+            first_air_date_lte: (optional) The maximum release to include. 
                                 Expected format is 'YYYY-MM-DD'.
           
         Returns:
             A dict respresentation of the JSON returned from the API.
         """
+        # Periods are not allowed in keyword arguments but severall API 
+        # arguments contain periods. 
+        for param in kwargs:
+            if '_lte' in param:
+                kwargs[param.replace('_lte', '.lte')] = kwargs.pop(param)
+            if '_gte' in param:
+                kwargs[param.replace('_gte', '.gte')] = kwargs.pop(param)
+        
         path = self._get_path('tv')
 
         response = self._GET(path, kwargs)


### PR DESCRIPTION
Severall API arguments contain periods which are not allowed in python parameters. This problem is solved by using underscores in the functions parameters and replacing them with the periods for the request. I also changed the docstrings. This pull request solves #18 