### PR TITLE
No more overwriting of response attributes and season id.

### DIFF
--- a/tmdbsimple/base.py
+++ b/tmdbsimple/base.py
@@ -45,7 +45,7 @@ class TMDB(object):
         return self._get_path(key).format(credit_id=self.credit_id)
 
     def _get_id_season_number_path(self, key):
-        return self._get_path(key).format(id=self.id,
+        return self._get_path(key).format(id=self.series_id,
             season_number=self.season_number)
 
     def _get_series_id_season_number_episode_number_path(self, key):

--- a/tmdbsimple/base.py
+++ b/tmdbsimple/base.py
@@ -102,5 +102,6 @@ class TMDB(object):
         """
         if isinstance(response, dict):
             for key in response.keys():
-                setattr(self, key, response[key])
+                if not hasattr(self, key):
+                    setattr(self, key, response[key])
 

--- a/tmdbsimple/movies.py
+++ b/tmdbsimple/movies.py
@@ -116,19 +116,16 @@ class Movies(TMDB):
         self._set_attrs_to_values(response)
         return response
 
-    def keywords(self, **kwargs):
+    def keywords(self):
         """
         Get the plot keywords for a specific movie id.
-        
-        Args:
-            append_to_response: (optional) Comma separated, any movie method.
 
         Returns:
             A dict respresentation of the JSON returned from the API.
         """
         path = self._get_id_path('keywords')
 
-        response = self._GET(path, kwargs)
+        response = self._GET(path)
         self._set_attrs_to_values(response)
         return response
 

--- a/tmdbsimple/tv.py
+++ b/tmdbsimple/tv.py
@@ -330,7 +330,7 @@ class TV_Seasons(TMDB):
 
     def __init__(self, id, season_number):
         super(TV_Seasons, self).__init__()
-        self.id = id
+        self.series_id = id
         self.season_number = season_number
 
     def info(self, **kwargs):


### PR DESCRIPTION
This pull request fixes issues #30 and #31.
#30: It doesn't set attributes if their is an attribute of the same name already. Less convenient as it may mean doing multiple similar Get requests, but eliminates this type change from callable to property.

#31: Changed `TV_Seasons.id` to `series_id` so calling `info()` or any other GET functions doesn't overwrite this id.
(Fixing #30 automatically fixed #31, but I think this is a proper way: symmetric to TV_Episodes.)