### PR TITLE
Fix #35 - bool typed params are not passed correctly

### DIFF
--- a/tmdbsimple/base.py
+++ b/tmdbsimple/base.py
@@ -64,6 +64,10 @@ class TMDB(object):
         api_dict = {'api_key': API_KEY}
         if params:
             params.update(api_dict)
+            for key, value in params.iteritems():
+                if isinstance(params[key], bool):
+                    params[key] = 'true' if value else 'false'
+
         else:
             params = api_dict
         return params

--- a/tmdbsimple/base.py
+++ b/tmdbsimple/base.py
@@ -64,9 +64,9 @@ class TMDB(object):
         api_dict = {'api_key': API_KEY}
         if params:
             params.update(api_dict)
-            for key, value in params.iteritems():
+            for key, value in params.items():
                 if isinstance(params[key], bool):
-                    params[key] = 'true' if value else 'false'
+                    params[key] = 'true' if value is True else 'false'
 
         else:
             params = api_dict


### PR DESCRIPTION
This does a simple check that looks for `bool` typed params and converts them to string values in lowercase.