### PR TITLE
Fix #45: Update Search attributes on multiple search queries

### DIFF
--- a/tmdbsimple/base.py
+++ b/tmdbsimple/base.py
@@ -102,6 +102,8 @@ class TMDB(object):
         """
         if isinstance(response, dict):
             for key in response.keys():
-                if not hasattr(self, key):
+                if not hasattr(self, key) or key in {'results', 'page', 
+                                                     'total_results', 
+                                                     'total_pages'}:
                     setattr(self, key, response[key])
 


### PR DESCRIPTION
This allows the attributes of a Search instance to change after multiple search query calls.