### PR TITLE
Implemented basic rate limiting

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     download_url = 'https://github.com/celiao/tmdbsimple/tarball/2.1.0',
     packages = ['tmdbsimple'],
     long_description=read('README.rst'),
-    install_requires = ['requests'],
+    install_requires = ['requests', 'ratelimit'],
     classifiers = [
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",

--- a/tmdbsimple/base.py
+++ b/tmdbsimple/base.py
@@ -82,7 +82,7 @@ class TMDB(object):
         response.encoding = 'utf-8'
         return response.json()
 
-	@rate_limited(4)
+    @rate_limited(4)
     def _GET(self, path, params=None):
         return self._request('GET', path, params=params)
 

--- a/tmdbsimple/base.py
+++ b/tmdbsimple/base.py
@@ -13,6 +13,7 @@ Created by Celia Oakley on 2013-10-31.
 
 import json
 import requests
+from ratelimit import *
 
 
 class APIKeyError(Exception):
@@ -81,6 +82,7 @@ class TMDB(object):
         response.encoding = 'utf-8'
         return response.json()
 
+	@rate_limited(4)
     def _GET(self, path, params=None):
         return self._request('GET', path, params=params)
 


### PR DESCRIPTION
themoveiedb.org API has a rate limiting feature that limits the number of requests that can be made to the API to 4 requests every 1 second.  If you are aggressively using tmdbsimple to retrieve data from themoviedb.org you can hit this limit quite quickly resulting in HTTP 429 errors.  For one of my own projects I solved this with two lines of code to base.py using the Python ratelimit package.  This will effectively throttle requests to the maximum rate supported and HTTP 429 errors no longer occur.