### PR TITLE
Decouple request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ Makefile
 # editors
 ## Vim files
 .*.swp
+.idea
 
 # other
 notes

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -12,8 +12,11 @@ Created by Celia Oakley on 2018-01-06
 :license: GPLv3, see LICENSE for more details.
 """
 
+import requests
+from requests import Response
 import unittest
 import tmdbsimple as tmdb
+from tmdbsimple import perform_request as original_request
 
 from tests import API_KEY, USERNAME, PASSWORD
 tmdb.API_KEY = API_KEY
@@ -22,8 +25,23 @@ tmdb.API_KEY = API_KEY
 Constants
 """
 MOVIE_ID = 103332
+MOVIE_TITLE = 'Ruby Sparks'
 MOVIEQUERY1 = 'Matrix'
 MOVIEQUERY2 = 'Star Wars'
+
+
+def my_test_request(method, url, params=None, data=None, headers=None):
+    return requests.request(
+        method, url, params=params, data=data, headers=headers)
+
+
+def my_fake_request(method, url, params=None, data=None, headers=None):
+    # returns empty OK response
+    response = Response()
+    response._content = b'{}'
+    response.status_code = 200
+    return response
+
 
 class TMDBTestCase(unittest.TestCase):
     # We want to be able to call methods multiple times.
@@ -50,3 +68,25 @@ class TMDBTestCase(unittest.TestCase):
         response = search.movie(query=MOVIEQUERY2)
         title2 = search.results[0]['original_title']
         self.assertNotEqual(title1, title2)
+
+
+class RequesterTestCase(unittest.TestCase):
+    def tearDown(self):
+        tmdb.perform_request = original_request
+
+    # Confirm that things still work with the request function replaced
+    # with our own.
+    def test_decoupled_request(self):
+        tmdb.perform_request = my_test_request
+        movie = tmdb.Movies(MOVIE_ID)
+        response = movie.info()
+        self.assertEqual(movie.title, MOVIE_TITLE)
+
+    # Confirm that things stop working with a faulty request function.
+    # Proofs that it's used.
+    def test_uncoupled_request(self):
+        tmdb.perform_request = my_fake_request
+        movie = tmdb.Movies(MOVIE_ID)
+        response = movie.info()
+        self.assertEqual(response, {})
+        self.assertFalse(hasattr(movie, 'title'))

--- a/tmdbsimple/__init__.py
+++ b/tmdbsimple/__init__.py
@@ -25,7 +25,7 @@ __license__ = 'GPLv3'
 import os
 
 from .account import Account, Authentication, GuestSessions, Lists
-from .base import APIKeyError
+from .base import APIKeyError, perform_request
 from .changes import Changes
 from .configuration import Configuration, Certifications, Timezones
 from .discover import Discover

--- a/tmdbsimple/base.py
+++ b/tmdbsimple/base.py
@@ -19,6 +19,11 @@ class APIKeyError(Exception):
     pass
 
 
+def perform_request(method, url, params=None, data=None, headers=None):
+    return requests.request(
+        method, url, params=params, data=data, headers=headers)
+
+
 class TMDB(object):
     headers = {'Content-Type': 'application/json',
                'Accept': 'application/json',
@@ -28,6 +33,8 @@ class TMDB(object):
 
     def __init__(self):
         from . import API_VERSION
+        from . import perform_request
+        self.perform_request = perform_request
         self.base_uri = 'https://api.themoviedb.org'
         self.base_uri += '/{version}'.format(version=API_VERSION)
 
@@ -71,11 +78,10 @@ class TMDB(object):
     def _request(self, method, path, params=None, payload=None):
         url = self._get_complete_url(path)
         params = self._get_params(params)
+        data = json.dumps(payload) if payload else payload
 
-        response = requests.request(
-            method, url, params=params, 
-            data=json.dumps(payload) if payload else payload,
-            headers=self.headers)
+        response = self.perform_request(
+            method, url, params=params, data=data, headers=self.headers)
 
         response.raise_for_status()
         response.encoding = 'utf-8'


### PR DESCRIPTION
With this pull request, using a rate-limiter, eg. RespectfulRequester, becomes as simple as defining the inner request method, like so:

```python
def respectful_request(method, url, params=None, data=None, headers=None):
    return rr.request(lambda: requests.request(
        method, url, params=params, data=data, headers=headers), realms=["TheMovieDB"], wait=True)
```

And in the module where tmdbsimple is used:

```python
from somewhere import respectful_request
import tmdbsimple as tmdb

tmdb.API_KEY = '...'
tmdb.perform_request = respectful_request
```

And voila: a rate-limited version of tmdbsimple!