### PR TITLE
update base.py to avoid 429 errors from api

### DIFF
--- a/tmdbsimple/base.py
+++ b/tmdbsimple/base.py
@@ -13,6 +13,7 @@ Created by Celia Oakley on 2013-10-31.
 
 import json
 import requests
+import time
 
 
 class APIKeyError(Exception):
@@ -72,10 +73,16 @@ class TMDB(object):
         url = self._get_complete_url(path)
         params = self._get_params(params)
 
-        response = requests.request(
-            method, url, params=params, 
-            data=json.dumps(payload) if payload else payload,
-            headers=self.headers)
+        retry = True
+        while retry:
+            retry = False
+            response = requests.request(
+                method, url, params=params, 
+                data=json.dumps(payload) if payload else payload,
+                headers=self.headers)
+        if response.status_code == 429:
+                retry = True
+                time.sleep(int(response.headers['Retry-After']))
 
         response.raise_for_status()
         response.encoding = 'utf-8'


### PR DESCRIPTION
getting lots of 429 errors.
found this and tested myself. no longer erroring out when scanning large collections.