### PR TITLE
Added request timeout setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,17 @@ import tmdbsimple as tmdb
 tmdb.API_KEY = 'YOUR_API_KEY_HERE'
 ```
 
+**(Optional)** Similarly you can also set a timeout for requests.
+
+```python
+tmdb.REQUEST_TIMEOUT = 5  # seconds
+```
+**OR**
+```python
+tmdb.REQUEST_TIMEOUT = (2, 5)  # seconds 
+```
+More details can be found [here](https://requests.readthedocs.io/en/master/user/advanced/#timeouts).
+
 To communicate with The Movie Database API, create an instance of one of the
 object types, call one of the methods on the instance, and access the instance
 attributes.  Use keys to access the values of attributes that are dictionaries.

--- a/tmdbsimple/__init__.py
+++ b/tmdbsimple/__init__.py
@@ -50,4 +50,5 @@ __all__ = ['Account', 'Authentication', 'GuestSessions', 'Lists',
            ]
 
 API_KEY = os.environ.get('TMDB_API_KEY', None)
+REQUEST_TIMEOUT = os.environ.get('REQUEST_TIMEOUT', None)
 API_VERSION = '3'

--- a/tmdbsimple/base.py
+++ b/tmdbsimple/base.py
@@ -77,13 +77,14 @@ class TMDB(object):
         return params
 
     def _request(self, method, path, params=None, payload=None):
+        from . import REQUEST_TIMEOUT
         url = self._get_complete_url(path)
         params = self._get_params(params)
 
         response = requests.request(
             method, url, params=params,
             data=json.dumps(payload) if payload else payload,
-            headers=self.headers)
+            headers=self.headers, timeout=REQUEST_TIMEOUT)
 
         response.raise_for_status()
         response.encoding = 'utf-8'


### PR DESCRIPTION
Recently I've faced this issue twice where processes get stuck indefinitely until service is restarted. Both times the culprit was not having a timeout.

Also `requests` recommends adding a timeout in every request. More details can be found [here](https://requests.readthedocs.io/en/master/user/quickstart/#timeouts).