### PR TITLE
Modify get params to use api_key defined in params

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -77,6 +77,7 @@ class TMDBTestCase(unittest.TestCase):
         tmdb.API_KEY = None
         with self.assertRaises(tmdb.base.APIKeyError):
             tmdb_no_api_defined._get_params(params={})
+        tmdb.API_KEY = API_KEY
 
     # confirm _get_params will NOT error when API_KEY is not defined but is added to the params
     # also confirm boolean conversion works
@@ -87,3 +88,15 @@ class TMDBTestCase(unittest.TestCase):
         expected = {'api_key': API_KEY, 'one_plus_one_is_two': 'true', 'cats=dogs': 'false'}
         actual = tmdb_no_api_defined._get_params(params=input_params)
         self.assertEqual(actual, expected)
+        tmdb.API_KEY = API_KEY
+
+    # simulate a normal search query with no API key previously defined
+    def test_tmdb_get_params_no_api_with_search(self):
+        search = tmdb.Search()
+        tmdb.API_KEY = None
+        search.movie(query=MOVIEQUERY3, include_adult=True, api_key=API_KEY)
+        total_results1 = search.total_results
+        search.movie(query=MOVIEQUERY3, include_adult='true', api_key=API_KEY)
+        total_results2 = search.total_results
+        self.assertEqual(total_results1, total_results2)
+        tmdb.API_KEY = API_KEY

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -61,3 +61,28 @@ class TMDBTestCase(unittest.TestCase):
         search.movie(query=MOVIEQUERY3, include_adult='true')
         total_results2 = search.total_results
         self.assertEqual(total_results1, total_results2)
+
+    # _get_params (1) adds the api key as a parameter and (2) turns all booleans into their string form.
+    # this test ensures these pieces of functionality when api_key is defined globally.
+    def test_get_params_only_api_key(self):
+        tmdb_object = tmdb.base.TMDB()
+        expected = {'api_key': API_KEY}
+        actual = tmdb_object._get_params(params={})
+        self.assertEqual(actual, expected)
+
+    # confirm _get_params will error when API_KEY is not defined
+    def test_get_params_api_key_undefined(self):
+        tmdb_no_api_defined = tmdb.base.TMDB()
+        tmdb.API_KEY = None
+        with self.assertRaises(tmdb.base.APIKeyError):
+            tmdb_no_api_defined._get_params(params={})
+
+    # confirm _get_params will NOT error when API_KEY is not defined but is added to the params
+    # also confirm boolean conversion works
+    def test_get_params_api_key_undefined_but_in_parameters(self):
+        tmdb_no_api_defined = tmdb.base.TMDB()
+        tmdb.API_KEY = None
+        input_params = {'api_key': API_KEY, 'one_plus_one_is_two': True, 'cats=dogs': False}
+        expected = {'api_key': API_KEY, 'one_plus_one_is_two': 'true', 'cats=dogs': 'false'}
+        actual = tmdb_no_api_defined._get_params(params=input_params)
+        self.assertEqual(actual, expected)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -65,6 +65,7 @@ class TMDBTestCase(unittest.TestCase):
     # _get_params (1) adds the api key as a parameter and (2) turns all booleans into their string form.
     # this test ensures these pieces of functionality when api_key is defined globally.
     def test_get_params_only_api_key(self):
+        tmdb.API_KEY = API_KEY
         tmdb_object = tmdb.base.TMDB()
         expected = {'api_key': API_KEY}
         actual = tmdb_object._get_params(params={})

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -61,3 +61,29 @@ class TMDBTestCase(unittest.TestCase):
         search.movie(query=MOVIEQUERY3, include_adult='true')
         total_results2 = search.total_results
         self.assertEqual(total_results1, total_results2)
+
+    # _get_params (1) adds the api key as a parameter and (2) turns all booleans into their string form.
+    # this test ensures these pieces of functionality when api_key is defined globally.
+    def test_get_params_only_api_key(self):
+        tmdb.API_KEY = API_KEY
+        tmdb_object = tmdb.base.TMDB()
+        expected = {'api_key': API_KEY}
+        actual = tmdb_object._get_params(params={})
+        self.assertEqual(actual, expected)
+
+    # confirm _get_params will error when API_KEY is not defined
+    def test_get_params_api_key_undefined(self):
+        tmdb_no_api_defined = tmdb.base.TMDB()
+        tmdb.API_KEY = None
+        with self.assertRaises(tmdb.base.APIKeyError):
+            tmdb_no_api_defined._get_params(params={})
+
+    # confirm _get_params will NOT error when API_KEY is not defined but is added to the params
+    # also confirm boolean conversion works
+    def test_get_params_api_key_undefined_but_in_parameters(self):
+        tmdb_no_api_defined = tmdb.base.TMDB()
+        tmdb.API_KEY = None
+        input_params = {'api_key': API_KEY, 'one_plus_one_is_two': True, 'cats=dogs': False}
+        expected = {'api_key': API_KEY, 'one_plus_one_is_two': 'true', 'cats=dogs': 'false'}
+        actual = tmdb_no_api_defined._get_params(params=input_params)
+        self.assertEqual(actual, expected)

--- a/tmdbsimple/base.py
+++ b/tmdbsimple/base.py
@@ -63,19 +63,18 @@ class TMDB(object):
         return '{base_uri}/{path}'.format(base_uri=self.base_uri, path=path)
 
     def _get_params(self, params):
-        from . import API_KEY
-        if not API_KEY:
-            raise APIKeyError
+        params = params if params else {}
 
-        api_dict = {'api_key': API_KEY}
-        if params:
-            params.update(api_dict)
-            for key, value in params.items():
-                if isinstance(params[key], bool):
-                    params[key] = 'true' if value is True else 'false'
+        if not params.get('api_key'):
+            from . import API_KEY
+            if not API_KEY:
+                raise APIKeyError
+            params['api_key'] = API_KEY
 
-        else:
-            params = api_dict
+        for key, value in params.items():
+            if isinstance(value, bool):
+                params[key] = str(value).lower()
+
         return params
 
     def _request(self, method, path, params=None, payload=None):

--- a/tmdbsimple/base.py
+++ b/tmdbsimple/base.py
@@ -72,8 +72,8 @@ class TMDB(object):
             params['api_key'] = API_KEY
 
         for key, value in params.items():
-            if isinstance(params[key], bool):
-                params[key] = 'true' if value is True else 'false'
+            if isinstance(value, bool):
+                params[key] = str(value).lower()
 
         return params
 

--- a/tmdbsimple/base.py
+++ b/tmdbsimple/base.py
@@ -63,19 +63,18 @@ class TMDB(object):
         return '{base_uri}/{path}'.format(base_uri=self.base_uri, path=path)
 
     def _get_params(self, params):
-        from . import API_KEY
-        if not API_KEY:
-            raise APIKeyError
+        params = params if params else {}
 
-        api_dict = {'api_key': API_KEY}
-        if params:
-            params.update(api_dict)
-            for key, value in params.items():
-                if isinstance(params[key], bool):
-                    params[key] = 'true' if value is True else 'false'
+        if not params.get('api_key'):
+            from . import API_KEY
+            if not API_KEY:
+                raise APIKeyError
+            params['api_key'] = API_KEY
 
-        else:
-            params = api_dict
+        for key, value in params.items():
+            if isinstance(params[key], bool):
+                params[key] = 'true' if value is True else 'false'
+
         return params
 
     def _request(self, method, path, params=None, payload=None):


### PR DESCRIPTION
the `_get_params` function only relied on `tmdb.API_KEY = ...` to set an API key. This PR aims to add functionality so that the user can specify an API key in every function to eliminate this global dependency. 

See the test `test_tmdb_get_params_no_api_with_search` in `test_base.py` for example usage. 

Also, this PR simplifies some boolean and string logic to for conciseness.  