### PR TITLE
fix(tv): Add missing 'return' statement in 'watch_providers()'

### DIFF
--- a/tmdbsimple/tv.py
+++ b/tmdbsimple/tv.py
@@ -335,6 +335,7 @@ class TV(TMDB):
 
         response = self._GET(path, kwargs)
         self._set_attrs_to_values(response)
+        return response
 
     def rating(self, **kwargs):
         """


### PR DESCRIPTION
Actually calling `tv.watch_providers()` always return `None`

This PR add the missing `return` statement in `tv.watch_providers()` function.

Signed-off-by: Lunik <lunik@tiwabbit.fr>