### PR TITLE
Watch Providers

### DIFF
--- a/tests/test_watch_providers.py
+++ b/tests/test_watch_providers.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+"""
+test_watch_providers.py
+~~~~~~~~~~~~~~~~~~~~~
+
+This test suite checks the methods of the WatchProviders class of tmdbsimple.
+
+Created by lardbit on 2024-09-02
+
+:copyright: (c) 2013-2022 by Celia Oakley.
+:license: GPLv3, see LICENSE for more details.
+"""
+
+import unittest
+import re
+import tmdbsimple as tmdb
+
+from tests import API_KEY
+tmdb.API_KEY = API_KEY
+"""
+Constants
+"""
+ISO_3166_1 = 'iso_3166_1'
+
+
+class WatchProvidersTestCase(unittest.TestCase):
+
+    def test_regions(self):
+        watch_providers = tmdb.WatchProviders()
+        response = watch_providers.watch_providers_available_regions()
+        # Regions are two uppercase letters
+        self.assertTrue(re.match('^[A-Z]{2}$', response.get('results', [])[0][ISO_3166_1]))
+
+    def test_watch_providers_movie_list(self):
+        watch_providers = tmdb.WatchProviders()
+        response = watch_providers.watch_providers_movie_list()
+        self.assertTrue(response.get('results', [])[0].get('provider_name'))
+
+    def test_watch_providers_tv_list(self):
+        watch_providers = tmdb.WatchProviders()
+        response = watch_providers.watch_providers_tv_list()
+        self.assertTrue(response.get('results', [])[0].get('provider_name'))

--- a/tmdbsimple/__init__.py
+++ b/tmdbsimple/__init__.py
@@ -23,7 +23,6 @@ __copyright__ = 'Copyright (c) 2013-2022 Celia Oakley'
 __license__ = 'GPLv3'
 
 import os
-import requests
 
 from .account import Account, Authentication, GuestSessions, Lists
 from .base import APIKeyError
@@ -36,19 +35,22 @@ from .movies import Movies, Collections, Companies, Keywords, Reviews
 from .people import People, Credits
 from .search import Search
 from .tv import TV, TV_Seasons, TV_Episodes, TV_Episode_Groups, TV_Changes, Networks
+from .watch_providers import WatchProviders
 
-__all__ = ['Account', 'Authentication', 'GuestSessions', 'Lists',
-           'APIKeyError',
-           'Changes',
-           'Configuration', 'Certifications',
-           'Discover',
-           'Find', 'Trending',
-           'Genres',
-           'Movies', 'Collections', 'Companies', 'Keywords', 'Reviews',
-           'People', 'Credits'
-           'Search',
-           'TV', 'TV_Seasons', 'TV_Episodes', 'TV_Episode_Groups', 'TV_Changes', 'Networks'
-           ]
+__all__ = [
+    'Account', 'Authentication', 'GuestSessions', 'Lists',
+    'APIKeyError',
+    'Changes',
+    'Configuration', 'Certifications',
+    'Discover',
+    'Find', 'Trending',
+    'Genres',
+    'Movies', 'Collections', 'Companies', 'Keywords', 'Reviews',
+    'People', 'Credits',
+    'Search',
+    'TV', 'TV_Seasons', 'TV_Episodes', 'TV_Episode_Groups', 'TV_Changes', 'Networks',
+    'WatchProviders',
+]
 
 API_KEY = os.environ.get('TMDB_API_KEY', None)
 API_VERSION = '3'

--- a/tmdbsimple/account.py
+++ b/tmdbsimple/account.py
@@ -48,7 +48,7 @@ class Account(TMDB):
         Args:
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_path('info')
         kwargs.update({'session_id': self.session_id})
@@ -68,7 +68,7 @@ class Account(TMDB):
             page: (optional) Minimum 1, maximum 1000, default 1.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('lists')
         kwargs.update({'session_id': self.session_id})
@@ -87,7 +87,7 @@ class Account(TMDB):
             page: (optional) Minimum 1, maximum 1000, default 1.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('favorite_movies')
         kwargs.update({'session_id': self.session_id})
@@ -106,7 +106,7 @@ class Account(TMDB):
             page: (optional) Minimum 1, maximum 1000, default 1.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('favorite_tv')
         kwargs.update({'session_id': self.session_id})
@@ -125,7 +125,7 @@ class Account(TMDB):
             favorite: True (to add) | False (to remove).
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('favorite')
         kwargs.update({'session_id': self.session_id})
@@ -150,7 +150,7 @@ class Account(TMDB):
             page: (optional) Minimum 1, maximum 1000, default 1.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('rated_movies')
         kwargs.update({'session_id': self.session_id})
@@ -169,7 +169,7 @@ class Account(TMDB):
             page: (optional) Minimum 1, maximum 1000, default 1.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('rated_tv')
         kwargs.update({'session_id': self.session_id})
@@ -188,7 +188,7 @@ class Account(TMDB):
             page: (optional) Minimum 1, maximum 1000, default 1.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('rated_tv_episodes')
         kwargs.update({'session_id': self.session_id})
@@ -207,7 +207,7 @@ class Account(TMDB):
             page: (optional) Minimum 1, maximum 1000, default 1.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('watchlist_movies')
         kwargs.update({'session_id': self.session_id})
@@ -226,7 +226,7 @@ class Account(TMDB):
             page: (optional) Minimum 1, maximum 1000, default 1.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('watchlist_tv')
         kwargs.update({'session_id': self.session_id})
@@ -245,7 +245,7 @@ class Account(TMDB):
             watchlist: True (to add) | False (to remove).
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('watchlist')
         kwargs.update({'session_id': self.session_id})
@@ -297,7 +297,7 @@ class Authentication(TMDB):
         Args:
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_path('guest_session_new')
 
@@ -314,7 +314,7 @@ class Authentication(TMDB):
         Args:
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_path('token_new')
 
@@ -335,7 +335,7 @@ class Authentication(TMDB):
                            used here.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_path('session_new')
 
@@ -364,7 +364,7 @@ class Authentication(TMDB):
             request_token: The token you generated for the user to approve.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_path('token_validate_with_login')
 
@@ -380,7 +380,7 @@ class Authentication(TMDB):
         Args:
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_path('session_delete')
 
@@ -419,7 +419,7 @@ class GuestSessions(TMDB):
             sort_by: (optional) Allowed Values: created_at.asc, created_at.desc
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_guest_session_id_path('rated_movies')
 
@@ -436,7 +436,7 @@ class GuestSessions(TMDB):
             sort_by: (optional) Allowed Values: created_at.asc, created_at.desc
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_guest_session_id_path('rated_tv')
 
@@ -453,7 +453,7 @@ class GuestSessions(TMDB):
             sort_by: (optional) Allowed Values: created_at.asc, created_at.desc
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_guest_session_id_path('rated_tv_episodes')
 
@@ -492,7 +492,7 @@ class Lists(TMDB):
             language: (optional) ISO 639-1 code.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('info')
 
@@ -509,7 +509,7 @@ class Lists(TMDB):
             movie_id: The id of the movie.  Minimum 1.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('item_status')
 
@@ -527,7 +527,7 @@ class Lists(TMDB):
             language: (optional) ISO 639-1 code.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_path('list_create')
         kwargs.update({'session_id': self.session_id})
@@ -551,7 +551,7 @@ class Lists(TMDB):
             media_id: A movie id.  Minimum 1.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('add_item')
         kwargs.update({'session_id': self.session_id})
@@ -572,7 +572,7 @@ class Lists(TMDB):
             media_id: A movie id.  Minimum 1.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('remove_item')
         kwargs.update({'session_id': self.session_id})
@@ -593,7 +593,7 @@ class Lists(TMDB):
             confirm: True (do it) | False (don't do it)
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('list_clear')
         kwargs.update({'session_id': self.session_id})
@@ -612,7 +612,7 @@ class Lists(TMDB):
             None
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('list_delete')
         kwargs.update({'session_id': self.session_id})

--- a/tmdbsimple/changes.py
+++ b/tmdbsimple/changes.py
@@ -42,7 +42,7 @@ class Changes(TMDB):
             page: (optional) Minimum 1, maximum 1000, default 1.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_path('movie')
 
@@ -65,7 +65,7 @@ class Changes(TMDB):
             page: (optional) Minimum 1, maximum 1000, default 1.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_path('tv')
 
@@ -88,7 +88,7 @@ class Changes(TMDB):
             page: (optional) Minimum 1, maximum 1000, default 1.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_path('person')
 

--- a/tmdbsimple/configuration.py
+++ b/tmdbsimple/configuration.py
@@ -57,7 +57,7 @@ class Configuration(TMDB):
             None
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_path('info')
 
@@ -73,7 +73,7 @@ class Configuration(TMDB):
             None
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_path('countries')
 
@@ -89,7 +89,7 @@ class Configuration(TMDB):
             None
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_path('jobs')
 
@@ -105,7 +105,7 @@ class Configuration(TMDB):
             None
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_path('languages')
 
@@ -121,7 +121,7 @@ class Configuration(TMDB):
             None
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_path('primary_translations')
 
@@ -137,7 +137,7 @@ class Configuration(TMDB):
             None
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_path('timezones')
 
@@ -166,7 +166,7 @@ class Certifications(TMDB):
             None
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_path('movie_list')
 
@@ -182,7 +182,7 @@ class Certifications(TMDB):
             None
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_path('tv_list')
 
@@ -199,7 +199,7 @@ class Certifications(TMDB):
             None
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_path('movie_list')
 

--- a/tmdbsimple/discover.py
+++ b/tmdbsimple/discover.py
@@ -138,7 +138,7 @@ class Discover(TMDB):
                 filter results by their original language value.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         # Periods are not allowed in keyword arguments but several API
         # arguments contain periods. See both usages in tests/test_discover.py.
@@ -237,7 +237,7 @@ class Discover(TMDB):
                 keyword.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         # Periods are not allowed in keyword arguments but several API
         # arguments contain periods. See both usages in tests/test_discover.py.

--- a/tmdbsimple/find.py
+++ b/tmdbsimple/find.py
@@ -49,7 +49,7 @@ class Find(TMDB):
                 instagram_id
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('info')
 
@@ -96,7 +96,7 @@ class Trending(TMDB):
             None
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_media_type_time_window_path('info')
 

--- a/tmdbsimple/genres.py
+++ b/tmdbsimple/genres.py
@@ -39,7 +39,7 @@ class Genres(TMDB):
             language: (optional) ISO 639-1 code.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_path('movie_list')
 
@@ -55,7 +55,7 @@ class Genres(TMDB):
             language: (optional) ISO 639-1 code.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_path('tv_list')
 
@@ -79,7 +79,7 @@ class Genres(TMDB):
                            Expected value is: True or False.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('movies')
 

--- a/tmdbsimple/people.py
+++ b/tmdbsimple/people.py
@@ -52,7 +52,7 @@ class People(TMDB):
                 namespace to the response.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('info')
 
@@ -75,7 +75,7 @@ class People(TMDB):
             page: (optional) Minimum 1, maximum 1000, default 1.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('changes')
 
@@ -91,7 +91,7 @@ class People(TMDB):
             language: (optional) ISO 639-1 code.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('movie_credits')
 
@@ -110,7 +110,7 @@ class People(TMDB):
             language: (optional) ISO 639-1 code.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('tv_credits')
 
@@ -126,7 +126,7 @@ class People(TMDB):
             language: (optional) ISO 639-1 code.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('combined_credits')
 
@@ -151,7 +151,7 @@ class People(TMDB):
             language: (optional) ISO 639-1 code.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('external_ids')
 
@@ -167,7 +167,7 @@ class People(TMDB):
             None
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('images')
 
@@ -184,7 +184,7 @@ class People(TMDB):
             page: (optional) Minimum 1, maximum 1000, default 1.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('tagged_images')
 
@@ -200,7 +200,7 @@ class People(TMDB):
             language: (optional) ISO 639-1 code.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('translations')
 
@@ -217,7 +217,7 @@ class People(TMDB):
             language: (optional) ISO 639-1 code.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_path('latest')
 
@@ -234,7 +234,7 @@ class People(TMDB):
             page: (optional) Minimum 1, maximum 1000, default 1.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_path('popular')
 
@@ -266,7 +266,7 @@ class Credits(TMDB):
             None
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_credit_id_path('info')
 

--- a/tmdbsimple/search.py
+++ b/tmdbsimple/search.py
@@ -41,7 +41,7 @@ class Search(TMDB):
             page: (optional) Minimum 1, maximum 1000, default 1.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_path('company')
 
@@ -60,7 +60,7 @@ class Search(TMDB):
             page: (optional) Minimum 1, maximum 1000, default 1.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_path('collection')
 
@@ -78,7 +78,7 @@ class Search(TMDB):
             page: (optional) Minimum 1, maximum 1000, default 1.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_path('keyword')
 
@@ -105,7 +105,7 @@ class Search(TMDB):
                 specific primary release year.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_path('movie')
 
@@ -129,7 +129,7 @@ class Search(TMDB):
                 dates. Must be uppercase.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_path('multi')
 
@@ -152,7 +152,7 @@ class Search(TMDB):
                 dates. Must be uppercase.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_path('person')
 
@@ -175,7 +175,7 @@ class Search(TMDB):
                 shows that have an air date with with value.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_path('tv')
 

--- a/tmdbsimple/tv.py
+++ b/tmdbsimple/tv.py
@@ -64,7 +64,7 @@ class TV(TMDB):
                 namespace to the response.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('info')
 
@@ -85,7 +85,7 @@ class TV(TMDB):
             guest_session_id: (optional) See Authentication.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('account_states')
 
@@ -101,7 +101,7 @@ class TV(TMDB):
             language: (optional) ISO 3166-1 code.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('alternative_titles')
 
@@ -118,7 +118,7 @@ class TV(TMDB):
             language: (optional) ISO 3166-1 code.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('content_ratings')
 
@@ -134,7 +134,7 @@ class TV(TMDB):
             language: (optional) ISO 639 code.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('credits')
 
@@ -151,7 +151,7 @@ class TV(TMDB):
             language: (optional) ISO 639 code.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('episode_groups')
 
@@ -174,7 +174,7 @@ class TV(TMDB):
             language: (optional) ISO 639 code.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('external_ids')
 
@@ -196,7 +196,7 @@ class TV(TMDB):
             language: (optional) ISO 639 code.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('images')
 
@@ -212,7 +212,7 @@ class TV(TMDB):
             None
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('keywords')
 
@@ -229,7 +229,7 @@ class TV(TMDB):
             page: (optional) Minimum 1, maximum 1000, default 1.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('recommendations')
 
@@ -246,7 +246,7 @@ class TV(TMDB):
             page: (optional) Minimum 1, maximum 1000, default 1.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('reviews')
 
@@ -263,7 +263,7 @@ class TV(TMDB):
             None
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('screened_theatrically')
 
@@ -281,7 +281,7 @@ class TV(TMDB):
             page: (optional) Minimum 1, maximum 1000, default 1.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('similar')
 
@@ -297,7 +297,7 @@ class TV(TMDB):
             None
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('translations')
 
@@ -313,7 +313,7 @@ class TV(TMDB):
             language: (optional) ISO 639 code.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('videos')
 
@@ -329,7 +329,7 @@ class TV(TMDB):
             None
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('watch_providers')
 
@@ -351,7 +351,7 @@ class TV(TMDB):
                 submit. The value is expected to be between 0.5 and 10.0.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('rating')
 
@@ -376,7 +376,7 @@ class TV(TMDB):
             guest_session_id: (optional) See Authentication.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('rating')
 
@@ -397,7 +397,7 @@ class TV(TMDB):
             language: (optional) ISO 639 code.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('latest')
 
@@ -419,7 +419,7 @@ class TV(TMDB):
             page: (optional) Minimum 1, maximum 1000, default 1.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_path('airing_today')
 
@@ -439,7 +439,7 @@ class TV(TMDB):
             page: (optional) Minimum 1, maximum 1000, default 1.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_path('on_the_air')
 
@@ -457,7 +457,7 @@ class TV(TMDB):
             page: (optional) Minimum 1, maximum 1000, default 1.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_path('popular')
 
@@ -474,7 +474,7 @@ class TV(TMDB):
             page: (optional) Minimum 1, maximum 1000, default 1.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_path('top_rated')
 
@@ -517,7 +517,7 @@ class TV_Seasons(TMDB):
                 namespace to the response.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_tv_id_season_number_path('info')
 
@@ -535,7 +535,7 @@ class TV_Seasons(TMDB):
             guest_session_id: (optional) See Authentication.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_tv_id_season_number_path('account_states')
 
@@ -551,7 +551,7 @@ class TV_Seasons(TMDB):
             language: (optional) ISO 639 code.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_tv_id_season_number_path('credits')
 
@@ -572,7 +572,7 @@ class TV_Seasons(TMDB):
             language: (optional) ISO 639 code.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_tv_id_season_number_path('external_ids')
 
@@ -594,7 +594,7 @@ class TV_Seasons(TMDB):
             language: (optional) ISO 639 code.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_tv_id_season_number_path('images')
 
@@ -610,7 +610,7 @@ class TV_Seasons(TMDB):
             language: (optional) ISO 639 code.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_tv_id_season_number_path('videos')
 
@@ -656,7 +656,7 @@ class TV_Episodes(TMDB):
                 namespace to the response.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_tv_id_season_number_episode_number_path('info')
 
@@ -673,7 +673,7 @@ class TV_Episodes(TMDB):
             guest_session_id: (optional) See Authentication.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_tv_id_season_number_episode_number_path(
             'account_states')
@@ -690,7 +690,7 @@ class TV_Episodes(TMDB):
             None
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_tv_id_season_number_episode_number_path('credits')
 
@@ -712,7 +712,7 @@ class TV_Episodes(TMDB):
             None
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_tv_id_season_number_episode_number_path(
             'external_ids')
@@ -735,7 +735,7 @@ class TV_Episodes(TMDB):
             None
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_tv_id_season_number_episode_number_path('images')
 
@@ -751,7 +751,7 @@ class TV_Episodes(TMDB):
             None
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_tv_id_season_number_episode_number_path(
             'translations')
@@ -775,7 +775,7 @@ class TV_Episodes(TMDB):
                 submit. The value is expected to be between 0.5 and 10.0.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_tv_id_season_number_episode_number_path('rating')
 
@@ -800,7 +800,7 @@ class TV_Episodes(TMDB):
             guest_session_id: (optional) See Authentication.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_tv_id_season_number_episode_number_path('rating')
 
@@ -820,7 +820,7 @@ class TV_Episodes(TMDB):
             language: (optional) ISO 639 code.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_tv_id_season_number_episode_number_path('videos')
 
@@ -860,7 +860,7 @@ class TV_Episode_Groups(TMDB):
             language: (optional) ISO 639 code.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('info')
 
@@ -909,7 +909,7 @@ class TV_Changes(TMDB):
             page: (optional) Minimum 1, maximum 1000, default 1.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('series')
 
@@ -932,7 +932,7 @@ class TV_Changes(TMDB):
             page: (optional) Minimum 1, maximum 1000, default 1.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('season')
 
@@ -955,7 +955,7 @@ class TV_Changes(TMDB):
             page: (optional) Minimum 1, maximum 1000, default 1.
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('episode')
 
@@ -989,7 +989,7 @@ class Networks(TMDB):
             None
 
         Returns:
-            A dict respresentation of the JSON returned from the API.
+            A dict representation of the JSON returned from the API.
         """
         path = self._get_id_path('info')
 

--- a/tmdbsimple/watch_providers.py
+++ b/tmdbsimple/watch_providers.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+
+"""
+tmdbsimple.watch_providers
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+This module implements the Watch Providers functionality of tmdbsimple.
+
+Created by lardbit on 2024-09-02.
+
+:copyright: (c) 2013-2022 by Celia Oakley
+:license: GPLv3, see LICENSE for more details
+"""
+
+from .base import TMDB
+
+
+class WatchProviders(TMDB):
+    """
+    Watch Providers functionality.
+
+    See: https://developer.themoviedb.org/reference/watch-providers-available-regions
+    See: https://developer.themoviedb.org/reference/watch-providers-movie-list
+    See: https://developer.themoviedb.org/reference/watch-provider-tv-list
+    """
+    BASE_PATH = 'watch'
+    URLS = {
+        'watch-providers-available-regions': '/providers/regions',
+        'watch-providers-movie-list': '/providers/movie',
+        'watch-provider-tv-list': '/providers/tv',
+    }
+
+    def watch_providers_available_regions(self, **kwargs):
+        """
+        Get the list of the countries we have watch provider (OTT/streaming) data for.
+
+        Args:
+            None
+
+        Returns:
+            A dict representation of the JSON returned from the API.
+        """
+        path = self._get_path('watch-providers-available-regions')
+
+        response = self._GET(path, kwargs)
+        self._set_attrs_to_values(response)
+        return response
+
+    def watch_providers_movie_list(self, **kwargs):
+        """
+        Get the list of streaming providers we have for movies.
+
+        Args:
+            None
+
+        Returns:
+            A dict representation of the JSON returned from the API.
+        """
+        path = self._get_path('watch-providers-movie-list')
+
+        response = self._GET(path, kwargs)
+        self._set_attrs_to_values(response)
+        return response
+
+    def watch_providers_tv_list(self, **kwargs):
+        """
+        Get the list of streaming providers we have for tv.
+
+        Args:
+            None
+
+        Returns:
+            A dict representation of the JSON returned from the API.
+        """
+        path = self._get_path('watch-provider-tv-list')
+
+        response = self._GET(path, kwargs)
+        self._set_attrs_to_values(response)
+        return response


### PR DESCRIPTION
This PR adds functionality for the *Watch Providers* endpoints:

- https://developer.themoviedb.org/reference/watch-providers-available-regions
-  https://developer.themoviedb.org/reference/watch-providers-movie-list 
- https://developer.themoviedb.org/reference/watch-provider-tv-list

Unit test are included as well:

    python -W ignore:ResourceWarning -m unittest tests.test_watch_providers
 

Usage:

    import tmdbsimple as tmdb
    watch_providers = tmdb.WatchProviders()
    watch_providers.watch_providers_available_regions()
    watch_providers.watch_providers_movie_list()
    watch_providers.watch_providers_tv_list()
