### PR TITLE
Replace broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ object.
 ```
 
 If you use Authentication to access a user Account, be sure to check out
-https://www.themoviedb.org/documentation/api/sessions.
+https://developer.themoviedb.org/docs/authentication-user.
 
 If you like this wrapper, and would like access to even more movie and TV data,
 check out *rtsimple* https://pypi.python.org/pypi/rtsimple, a wrapper for the


### PR DESCRIPTION
The hyperlink to the Movie Database API documentation on line 170 of the [README.md](https://github.com/celiao/tmdbsimple/blob/0b3359f7bab3ade391b2e5de964ed115b00984a6/README.md) file takes visitors to a 404 page.  It appears the web page has moved. Below is the hyperlink in question:

https://github.com/celiao/tmdbsimple/blob/0b3359f7bab3ade391b2e5de964ed115b00984a6/README.md?plain=1#L170

The [web page that once lived at the URL found on line 170](https://web.archive.org/web/20230211044422/https://www.themoviedb.org/documentation/api/sessions) most closely the ['User' web page](https://developer.themoviedb.org/docs/authentication-user) in the current TMBD API docs.

This PR replaces the former hyperlink with the latter.