### PR TITLE
Add USE_BEARER_AUTH option

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ import requests
 tmdb.REQUESTS_SESSION = requests.Session()
 ```
 
+_Optionally_, configure the library to use bearer authentication. This may be useful if you
+encounter authorization issues with the default method of passing the API key via URL parameters.
+
+```python
+tmdb.USE_BEARER_AUTH = True
+```
+
 To communicate with The Movie Database API, create an instance of one of the
 object types, call one of the methods on the instance, and access the instance
 attributes.  Use keys to access the values of attributes that are dictionaries.

--- a/tmdbsimple/__init__.py
+++ b/tmdbsimple/__init__.py
@@ -54,3 +54,4 @@ API_KEY = os.environ.get('TMDB_API_KEY', None)
 API_VERSION = '3'
 REQUESTS_SESSION = None
 REQUESTS_TIMEOUT = os.environ.get('TMDB_REQUESTS_TIMEOUT', None)
+USE_BEARER_AUTH = os.environ.get('TMDB_USE_BEARER_AUTH', 'no').lower() in ('y', 'yes', '1')

--- a/tmdbsimple/base.py
+++ b/tmdbsimple/base.py
@@ -27,11 +27,17 @@ class TMDB(object):
     URLS = {}
 
     def __init__(self):
-        from . import API_VERSION, REQUESTS_SESSION, REQUESTS_TIMEOUT
+        from . import API_VERSION, REQUESTS_SESSION, REQUESTS_TIMEOUT, USE_BEARER_AUTH, API_KEY
         self.base_uri = 'https://api.themoviedb.org'
         self.base_uri += '/{version}'.format(version=API_VERSION)
         self.session = REQUESTS_SESSION
         self.timeout = REQUESTS_TIMEOUT
+
+        if USE_BEARER_AUTH:
+            if not API_KEY:
+                raise APIKeyError
+            
+            self.headers['Authorization'] = f'Bearer {API_KEY}'
 
     def _get_path(self, key):
         return self.BASE_PATH + self.URLS[key]
@@ -63,11 +69,15 @@ class TMDB(object):
         return '{base_uri}/{path}'.format(base_uri=self.base_uri, path=path)
 
     def _get_params(self, params):
-        from . import API_KEY
+        from . import API_KEY, USE_BEARER_AUTH
         if not API_KEY:
             raise APIKeyError
 
-        api_dict = {'api_key': API_KEY}
+        if USE_BEARER_AUTH:
+            api_dict = {}
+        else:
+            api_dict = {'api_key': API_KEY}
+
         if params:
             params.update(api_dict)
             for key, value in params.items():


### PR DESCRIPTION
Some users experience issues with providing their API key via the the request parameters. TMDb documentation seems to prefer bearer authentication. Provide a `USE_BEARER_AUTH` knob to enable this.